### PR TITLE
Make path prefix dynamic instead of only /klanten

### DIFF
--- a/api/src/Controller/ZZController.php
+++ b/api/src/Controller/ZZController.php
@@ -61,9 +61,10 @@ class ZZController extends AbstractController
      * @TODO This function needs to be more dynamic: /{item}/api/{path}.
      * This function dynamically handles the custom endpoints.
      *
-     * @Route("/klanten/api/{path}", name="dynamic_route_second", requirements={"path" = ".+"})
+     * @Route("/{prefix}/api/{path}", name="dynamic_route_second", requirements={"path" = ".+"})
      *
      * @param string|null $path
+     * @param string|null $bundle
      * @param Request $request
      * @param EndpointService $endpointService
      * @return Response
@@ -71,6 +72,7 @@ class ZZController extends AbstractController
      */
     public function dynamicCustomAction(
         ?string $path,
+        ?string $bundle,
         Request $request,
         EndpointService $endpointService
     ): Response {


### PR DESCRIPTION
This allows api to be prefixed by anything not containing a /. 
In a later stadium it would be good to have a functionality to check if a prefix is allowed for an endpoint