### PR TITLE
Hotfix for BRK too large objects

### DIFF
--- a/api/src/Entity/ObjectEntity.php
+++ b/api/src/Entity/ObjectEntity.php
@@ -1257,6 +1257,11 @@ class ObjectEntity
                                 $config['maxDepth'] = $attribute->getObject()->getMaxDepth() + $config['level'];
                             }
                             $config['level'] = $config['level'] + 1;
+
+                            //TODO: This is a very hacky solution that has to be changed back ASAP
+                            if ($attribute->getObject() === $this->getEntity()) {
+                                $config['maxDepth'] = $config['level'];
+                            }
                             $objectToArray = $object->toArray($config);
 
                             // Check if we want an embedded array


### PR DESCRIPTION
This hotfix should be reverted ASAP and superceded by a possibility to overrule maxDepth per attribute.
